### PR TITLE
Add calendar view switcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@react-google-maps/api": "^2.20.7",
         "@tippyjs/react": "^4.2.6",
         "date-fns": "^4.1.0",
+        "date-fns-tz": "^3.2.0",
         "lucide-react": "^0.525.0",
         "next": "15.3.5",
         "react": "^19.1.0",
@@ -3047,6 +3048,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@react-google-maps/api": "^2.20.7",
     "@tippyjs/react": "^4.2.6",
     "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "lucide-react": "^0.525.0",
     "next": "15.3.5",
     "react": "^19.1.0",

--- a/src/app/admin/calendar/CalendarClient.tsx
+++ b/src/app/admin/calendar/CalendarClient.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import type { EventRecord } from "@/lib/types";
+import CalendarView from "@/components/Calendar/CalendarView";
+import { addDays, addWeeks, addMonths, startOfWeek } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
+
+export default function CalendarClient({ events }: { events: EventRecord[] }) {
+  const [view, setView] = useState<"day" | "week" | "month">("week");
+  const [timeZone, setTimeZone] = useState(
+    Intl.DateTimeFormat().resolvedOptions().timeZone
+  );
+  const [currentDate, setCurrentDate] = useState(new Date());
+
+  const VIEWS: ("day" | "week" | "month")[] = ["day", "week", "month"];
+
+  const header = useMemo(() => {
+    switch (view) {
+      case "day":
+        return formatInTimeZone(currentDate, timeZone, "EEEE, MMMM d, yyyy");
+      case "week": {
+        const start = startOfWeek(currentDate, { weekStartsOn: 1 });
+        const end = addDays(start, 6);
+        return `${formatInTimeZone(start, timeZone, "MMM d")} - ${formatInTimeZone(end, timeZone, "MMM d, yyyy")}`;
+      }
+      default:
+        return formatInTimeZone(currentDate, timeZone, "MMMM yyyy");
+    }
+  }, [view, currentDate, timeZone]);
+
+  const navigate = (dir: -1 | 1) => {
+    setCurrentDate((d) => {
+      switch (view) {
+        case "day":
+          return addDays(d, dir);
+        case "week":
+          return addWeeks(d, dir);
+        default:
+          return addMonths(d, dir);
+      }
+    });
+  };
+
+  const tzOptions = useMemo(() => Intl.supportedValuesOf("timeZone"), []);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="inline-flex overflow-hidden rounded-full border bg-white">
+          {VIEWS.map((v) => (
+            <button
+              key={v}
+              onClick={() => setView(v)}
+              className={`px-4 py-2 text-sm font-medium capitalize transition ${
+                view === v
+                  ? "bg-blue-600 text-white"
+                  : "text-slate-700 hover:bg-blue-50 hover:text-blue-600"
+              }`}
+            >
+              {v}
+            </button>
+          ))}
+        </div>
+        <div className="flex items-center space-x-2">
+          <button
+            onClick={() => navigate(-1)}
+            className="rounded border px-2 py-1 text-sm bg-white hover:bg-gray-50"
+          >
+            Prev
+          </button>
+          <span className="font-semibold">{header}</span>
+          <button
+            onClick={() => navigate(1)}
+            className="rounded border px-2 py-1 text-sm bg-white hover:bg-gray-50"
+          >
+            Next
+          </button>
+          <select
+            value={timeZone}
+            onChange={(e) => setTimeZone(e.target.value)}
+            className="ml-2 rounded border px-2 py-1 text-sm"
+          >
+            {tzOptions.map((tz) => (
+              <option key={tz} value={tz}>
+                {tz}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <div className="h-[calc(100vh-16rem)]">
+        <CalendarView view={view} events={events} date={currentDate} timeZone={timeZone} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/calendar/page.tsx
+++ b/src/app/admin/calendar/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from 'next';
 import { listAllEvents } from '@/lib/adminApi';
 import type { EventRecord } from '@/lib/types';
-import CalendarView from '@/components/Calendar/CalendarView';
+import CalendarClient from './CalendarClient';
 
 export const metadata: Metadata = {
   title: 'Calendar – Institution Admin',
@@ -11,6 +11,6 @@ export default async function CalendarPage() {
   // Fetch all events on the server
   const events: EventRecord[] = await listAllEvents();
 
-  // Render the client-side CalendarView with a default week view
-  return <CalendarView view="week" events={events} />;
+  // Render a client component so the user can switch views
+  return <CalendarClient events={events} />;
 }

--- a/src/components/Calendar/CalendarView.tsx
+++ b/src/components/Calendar/CalendarView.tsx
@@ -2,6 +2,15 @@
 
 import React from 'react';
 import type { EventRecord } from '@/lib/types';
+import {
+  startOfDay,
+  endOfDay,
+  startOfWeek,
+  endOfWeek,
+  startOfMonth,
+  endOfMonth,
+} from 'date-fns';
+import { toZonedTime, fromZonedTime } from 'date-fns-tz';
 import DayView from './DayView';
 import WeekView from './WeekView';
 import MonthView from './MonthView';
@@ -12,31 +21,62 @@ export interface Event {
   start: string;
   end: string;
   category?: string;
+  status?: string;
 }
 
 export interface CalendarViewProps {
   events: EventRecord[];
   view: 'day' | 'week' | 'month';
+  date: Date;
+  timeZone: string;
   onSelectEvent?: (id: string) => void;
 }
 
-export default function CalendarView({ events, view, onSelectEvent }: CalendarViewProps) {
-  const normalized: Event[] = events
+export default function CalendarView({ events, view, date, timeZone, onSelectEvent }: CalendarViewProps) {
+  const localized: Event[] = events
     .filter(e => e.start && e.end)
-    .map(e => ({
-      id: e.id,
-      title: e.title,
-      start: e.start as string,
-      end: e.end as string,
-      category: e.category,
-    }));
+    .map(e => {
+      const startUtc = fromZonedTime(e.start as string, e.timezone || timeZone);
+      const endUtc = fromZonedTime(e.end as string, e.timezone || timeZone);
+      const start = toZonedTime(startUtc, timeZone).toISOString();
+      const end = toZonedTime(endUtc, timeZone).toISOString();
+      return {
+        id: e.id,
+        title: e.title,
+        start,
+        end,
+        category: e.category,
+        status: e.status,
+      };
+    });
 
   switch (view) {
-    case 'day':
-      return <DayView events={normalized} onSelectEvent={onSelectEvent} />;
-    case 'week':
-      return <WeekView events={normalized} onSelectEvent={onSelectEvent} />;
-    default:
-      return <MonthView events={normalized} onSelectEvent={onSelectEvent} />;
+    case 'day': {
+      const startDay = startOfDay(date);
+      const endDay = endOfDay(date);
+      const viewEvents = localized.filter(ev => {
+        const s = new Date(ev.start);
+        return s >= startDay && s <= endDay;
+      });
+      return <DayView events={viewEvents} date={date} timezone={timeZone} onSelectEvent={onSelectEvent} />;
+    }
+    case 'week': {
+      const weekStart = startOfWeek(date, { weekStartsOn: 1 });
+      const weekEnd = endOfWeek(date, { weekStartsOn: 1 });
+      const viewEvents = localized.filter(ev => {
+        const s = new Date(ev.start);
+        return s >= weekStart && s <= weekEnd;
+      });
+      return <WeekView events={viewEvents} startDate={weekStart} timezone={timeZone} onSelectEvent={onSelectEvent} />;
+    }
+    default: {
+      const monthStart = startOfMonth(date);
+      const monthEnd = endOfMonth(date);
+      const viewEvents = localized.filter(ev => {
+        const s = new Date(ev.start);
+        return s >= monthStart && s <= monthEnd;
+      });
+      return <MonthView events={viewEvents} month={monthStart} timezone={timeZone} onSelectEvent={onSelectEvent} />;
+    }
   }
 }

--- a/src/components/Calendar/DayView.tsx
+++ b/src/components/Calendar/DayView.tsx
@@ -2,12 +2,15 @@
 
 import React, { useMemo } from 'react';
 import { differenceInMinutes } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
 import { Event } from './CalendarView';
 import { computeDayPositions, type DayPosition } from './OverlapUtils';
 
 
 export interface DayViewProps {
-  events: Event[];          // All events for the current day
+  events: Event[]; // Events already filtered to the current day
+  date: Date;
+  timezone: string;
   onSelectEvent?: (id: string) => void;
 }
 
@@ -20,7 +23,7 @@ const CATEGORY_COLORS: Record<string, string> = {
   Default: '#3b82f6',
 };
 
-export default function DayView({ events, onSelectEvent }: DayViewProps) {
+export default function DayView({ events, date, timezone, onSelectEvent }: DayViewProps) {
   // Compute overlapping columns for the day events
   const positioned = useMemo<DayPosition[]>(
     () => computeDayPositions(events),
@@ -28,7 +31,11 @@ export default function DayView({ events, onSelectEvent }: DayViewProps) {
   );
 
   return (
-    <div className="flex h-full overflow-hidden">
+    <div className="flex h-full overflow-hidden flex-col">
+      <div className="text-center font-semibold py-1 border-b border-gray-200 bg-white sticky top-0 z-10">
+        {formatInTimeZone(date, timezone, 'EEEE, MMMM d')}
+      </div>
+      <div className="flex flex-1 overflow-hidden">
       {/* Hour labels */}
       <div className="w-12 flex flex-col border-r border-gray-200">
         {Array.from({ length: 24 }).map((_, i) => (
@@ -62,6 +69,7 @@ export default function DayView({ events, onSelectEvent }: DayViewProps) {
           const widthPct = 100 / cols;
           const leftPct = col * widthPct;
           const bg = CATEGORY_COLORS[event.category || 'Default'];
+          const opacity = event.status === 'pending' ? 0.5 : 1;
 
           return (
             <div
@@ -73,6 +81,7 @@ export default function DayView({ events, onSelectEvent }: DayViewProps) {
                 left: `${leftPct}%`,
                 width: `calc(${widthPct}% - 4px)`,
                 backgroundColor: bg,
+                opacity,
               }}
               onClick={() => onSelectEvent?.(event.id)}
               title={`${event.title} (${startDate.getHours()}:${String(startDate.getMinutes()).padStart(2, '0')} - ${endDate.getHours()}:${String(endDate.getMinutes()).padStart(2, '0')})`}
@@ -81,6 +90,7 @@ export default function DayView({ events, onSelectEvent }: DayViewProps) {
             </div>
           );
         })}
+      </div>
       </div>
     </div>
   );

--- a/src/components/Calendar/MonthView.tsx
+++ b/src/components/Calendar/MonthView.tsx
@@ -10,10 +10,13 @@ import {
   addDays,
   isSameMonth,
 } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
 import { Event } from './CalendarView';
 
 export interface MonthViewProps {
   events: Event[];
+  month: Date;
+  timezone: string;
   onSelectEvent?: (id: string) => void;
 }
 
@@ -25,9 +28,8 @@ const CATEGORY_COLORS: Record<string, string> = {
   Default: '#3b82f6',
 };
 
-export default function MonthView({ events, onSelectEvent }: MonthViewProps) {
-  const today = new Date();
-  const monthStart = startOfMonth(today);
+export default function MonthView({ events, month, timezone, onSelectEvent }: MonthViewProps) {
+  const monthStart = startOfMonth(month);
   const monthEnd = endOfMonth(monthStart);
   const calendarStart = startOfWeek(monthStart, { weekStartsOn: 1 }); // Monday
   const calendarEnd = endOfWeek(monthEnd, { weekStartsOn: 1 });
@@ -79,7 +81,7 @@ export default function MonthView({ events, onSelectEvent }: MonthViewProps) {
           >
             {/* Day number */}
             <div className="absolute top-1 right-1 text-xs text-gray-500">
-              {format(day, 'd')}
+              {formatInTimeZone(day, timezone, 'd')}
             </div>
 
             {/* Events list (up to 3) */}
@@ -89,16 +91,17 @@ export default function MonthView({ events, onSelectEvent }: MonthViewProps) {
                   key={ev.id}
                   className="flex items-center text-xs truncate cursor-pointer"
                   onClick={() => onSelectEvent?.(ev.id)}
-                  title={`${ev.title} (${format(new Date(ev.start), 'HH:mm')} - ${format(
+                  title={`${ev.title} (${formatInTimeZone(new Date(ev.start), timezone, 'HH:mm')} - ${formatInTimeZone(
                     new Date(ev.end),
+                    timezone,
                     'HH:mm'
                   )})`}
                 >
                   <span
                     className="inline-block w-2 h-2 rounded-full mr-1 flex-shrink-0"
-                    style={{ backgroundColor: CATEGORY_COLORS[ev.category || 'Default'] }}
+                    style={{ backgroundColor: CATEGORY_COLORS[ev.category || 'Default'], opacity: ev.status === 'pending' ? 0.5 : 1 }}
                   />
-                  <span className="truncate">{ev.title}</span>
+                  <span className={`truncate ${ev.status === 'pending' ? 'opacity-50' : ''}`}>{ev.title}</span>
                 </div>
               ))}
               {dayEvents.length > 3 && (

--- a/src/components/Calendar/WeekView.tsx
+++ b/src/components/Calendar/WeekView.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import React, { useMemo } from 'react';
-import { differenceInMinutes } from 'date-fns';
+import { differenceInMinutes, addDays } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
 import { Event } from './CalendarView';
 import { computeWeekPositions, type WeekPosition } from './OverlapUtils';
 
@@ -15,13 +16,17 @@ const CATEGORY_COLORS: Record<string, string> = {
 
 export interface WeekViewProps {
   events: Event[];
+  startDate: Date;
+  timezone: string;
   onSelectEvent?: (id: string) => void;
 }
 
 const CELL_HEIGHT = 48; // pixels per hour
 
-export default function WeekView({ events, onSelectEvent }: WeekViewProps) {
+export default function WeekView({ events, startDate, timezone, onSelectEvent }: WeekViewProps) {
   const now = new Date();
+
+  const days = Array.from({ length: 7 }).map((_, i) => addDays(startDate, i));
 
   const positioned = useMemo<WeekPosition[]>(
     () => computeWeekPositions(events),
@@ -29,73 +34,84 @@ export default function WeekView({ events, onSelectEvent }: WeekViewProps) {
   );
 
   return (
-    <div className="flex h-full overflow-hidden">
-      {/* Hour labels */}
-      <div className="w-12 flex flex-col border-r border-gray-200">
-        {Array.from({ length: 24 }).map((_, i) => (
-          <div
-            key={i}
-            className="h-48 flex items-start justify-end pr-1 text-xs text-gray-500"
-          >
-            {i}:00
+    <div className="flex h-full overflow-hidden flex-col">
+      <div className="grid grid-cols-7 border-b border-gray-200 bg-white text-center text-xs font-semibold sticky top-0 z-10">
+        {days.map((d, idx) => (
+          <div key={idx} className="py-1 border-r last:border-r-0">
+            {formatInTimeZone(d, timezone, 'EEE d')}
           </div>
         ))}
       </div>
-
-      {/* Days grid and events */}
-      <div className="relative flex-1 grid grid-cols-7 border-l border-gray-200">
-        {/* Half-hour grid lines */}
-        <div className="absolute inset-0 grid grid-rows-[repeat(48,minmax(0,1fr))] w-full">
-          {Array.from({ length: 48 }).map((_, idx) => (
+      <div className="flex flex-1 overflow-hidden">
+        {/* Hour labels */}
+        <div className="w-12 flex flex-col border-r border-gray-200">
+          {Array.from({ length: 24 }).map((_, i) => (
             <div
-              key={idx}
-              className={idx % 2 === 0 ? 'border-t border-gray-200' : 'border-t border-gray-100'}
-            />
+              key={i}
+              className="h-48 flex items-start justify-end pr-1 text-xs text-gray-500"
+            >
+              {i}:00
+            </div>
           ))}
         </div>
 
-        {/* Day columns */}
-        {Array.from({ length: 7 }).map((_, dayIdx) => (
-          <div key={dayIdx} className="col-span-1 border-r border-gray-200" />
-        ))}
+        {/* Days grid and events */}
+        <div className="relative flex-1 grid grid-cols-7 border-l border-gray-200">
+          {/* Half-hour grid lines */}
+          <div className="absolute inset-0 grid grid-rows-[repeat(48,minmax(0,1fr))] w-full">
+            {Array.from({ length: 48 }).map((_, idx) => (
+              <div
+                key={idx}
+                className={idx % 2 === 0 ? 'border-t border-gray-200' : 'border-t border-gray-100'}
+              />
+            ))}
+          </div>
 
-        {/* Current time indicator */}
-        {['Mon','Tue','Wed','Thu','Fri','Sat','Sun'].includes(now.toDateString().slice(0,3)) && (
-          <div
-            className="absolute h-px bg-red-500 w-full"
-            style={{ top: (now.getHours() + now.getMinutes() / 60) * CELL_HEIGHT }}
-          />
-        )}
+          {/* Day columns */}
+          {Array.from({ length: 7 }).map((_, dayIdx) => (
+            <div key={dayIdx} className="col-span-1 border-r border-gray-200" />
+          ))}
 
-        {/* Event blocks */}
-        {positioned.map(({ event, day, col, cols }) => {
-          const startDate = new Date(event.start);
-          const endDate = new Date(event.end);
-          const minutesFromMid = startDate.getHours() * 60 + startDate.getMinutes();
-          const durationMin = differenceInMinutes(endDate, startDate);
-          const baseLeft = (day / 7) * 100;
-          const widthPct = 100 / 7 / cols;
-          const leftPct = baseLeft + col * widthPct;
-          const bg = CATEGORY_COLORS[event.category || 'Default'];
-
-          return (
+          {/* Current time indicator */}
+          {['Mon','Tue','Wed','Thu','Fri','Sat','Sun'].includes(now.toDateString().slice(0,3)) && (
             <div
-              key={event.id}
-              className="absolute rounded text-white text-xs p-1 overflow-hidden cursor-pointer"
-              style={{
-                top: (minutesFromMid / 60) * CELL_HEIGHT,
-                height: (durationMin / 60) * CELL_HEIGHT,
-                left: `${leftPct}%`,
-                width: `calc(${widthPct}% - 4px)`,
-                backgroundColor: bg,
-              }}
-              onClick={() => onSelectEvent?.(event.id)}
-              title={`${event.title} (${startDate.getHours()}:${String(startDate.getMinutes()).padStart(2,'0')} - ${endDate.getHours()}:${String(endDate.getMinutes()).padStart(2,'0')})`}
-            >
-              {event.title}
-            </div>
-          );
-        })}
+              className="absolute h-px bg-red-500 w-full"
+              style={{ top: (now.getHours() + now.getMinutes() / 60) * CELL_HEIGHT }}
+            />
+          )}
+
+          {/* Event blocks */}
+          {positioned.map(({ event, day, col, cols }) => {
+            const startDateObj = new Date(event.start);
+            const endDateObj = new Date(event.end);
+            const minutesFromMid = startDateObj.getHours() * 60 + startDateObj.getMinutes();
+            const durationMin = differenceInMinutes(endDateObj, startDateObj);
+            const baseLeft = (day / 7) * 100;
+            const widthPct = 100 / 7 / cols;
+            const leftPct = baseLeft + col * widthPct;
+            const bg = CATEGORY_COLORS[event.category || 'Default'];
+            const opacity = event.status === 'pending' ? 0.5 : 1;
+
+            return (
+              <div
+                key={event.id}
+                className="absolute rounded text-white text-xs p-1 overflow-hidden cursor-pointer"
+                style={{
+                  top: (minutesFromMid / 60) * CELL_HEIGHT,
+                  height: (durationMin / 60) * CELL_HEIGHT,
+                  left: `${leftPct}%`,
+                  width: `calc(${widthPct}% - 4px)`,
+                  backgroundColor: bg,
+                  opacity,
+                }}
+                onClick={() => onSelectEvent?.(event.id)}
+                title={`${event.title} (${startDateObj.getHours()}:${String(startDateObj.getMinutes()).padStart(2,'0')} - ${endDateObj.getHours()}:${String(endDateObj.getMinutes()).padStart(2,'0')})`}
+              >
+                {event.title}
+              </div>
+            );
+          })}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow switching between day, week and month views on the calendar
- support timezone selection and navigation between periods
- show headers with formatted dates
- filter events to the correct period and indicate pending events

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: no-unused-vars and other existing issues)*